### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/tianyanlong/24860921-e7d9-427d-9734-00d1636711b2/b6c13e10-f241-4b20-856e-344f8bc4afe6/_apis/work/boardbadge/32a9f2bd-2f7c-4133-a242-25408e5c8d73)](https://dev.azure.com/tianyanlong/24860921-e7d9-427d-9734-00d1636711b2/_boards/board/t/b6c13e10-f241-4b20-856e-344f8bc4afe6/Microsoft.RequirementCategory)
 <div align="center">
 <p>
    <a align="left" href="https://ultralytics.com/yolov5" target="_blank">


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#1. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.